### PR TITLE
Revert "Update pomegranate dependency version"

### DIFF
--- a/Dockerfile
+++ b/Dockerfile
@@ -13,4 +13,4 @@ COPY ./hack/requirements.txt /
 RUN pip install -r /requirements.txt && rm /requirements.txt
 # There's an upstream bug with dependency resolution
 # keep this here, outside requirements!!
-RUN pip install pomegranate==0.8.1
+RUN pip install pomegranate==0.7.3


### PR DESCRIPTION
Reverts fabric8-analytics/fabric8-analytics-stack-analysis-base#3. @abs51295 had a failing image on his dev cluster. So I guess when doing this we need to train the model first and upgrade the dependency later.